### PR TITLE
Update go.mod to fix a problem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/HimbeerserverDE/multiserver/multiserver_converter
+module github.com/HimbeerserverDE/multiserver_converter
 
 go 1.16
 


### PR DESCRIPTION
go: downloading github.com/HimbeerserverDE/multiserver_converter v0.0.0-20210422131131-c30712e7050b
go: github.com/HimbeerserverDE/multiserver_converter@latest: version constraints conflict:
	github.com/HimbeerserverDE/multiserver_converter@v0.0.0-20210422131131-c30712e7050b: parsing go.mod:
	module declares its path as: github.com/HimbeerserverDE/multiserver/multiserver_converter
	        but was required as: github.com/HimbeerserverDE/multiserver_converter